### PR TITLE
fix npm commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web"
+    "build": "npx expo prebuild",
+    "android": "npx expo run:android",
+    "ios": "npx expo run:ios",
+    "web": "npx expo run:web"
   },
   "dependencies": {
     "@viro-community/react-viro": "^2.41.0",


### PR DESCRIPTION
since viro react requires the expo prebuild workflow, and does not support expo go.